### PR TITLE
chore: change local notification service port

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ csrs:
   deleteUrl: "${csrs.serviceUrl}/civilServants/%s/delete"
 
 notifications:
-  service: ${NOTIFICATION_SERVICE_URL:http://localhost:9005}
+  service: ${NOTIFICATION_SERVICE_URL:http://localhost:9006}
   email: "${notifications.service}/notifications/email/"
 
 accountPeriodsInMonths:


### PR DESCRIPTION
_This is just a change to make local dev set up easier, not related to a JIRA ticket_

Local instance of notification service was running on port 9005. This was causing some conflicts with other things running on the same port so have moved to port 9006. 

Local changes only - wont impact any other environments