### PR TITLE
Updating Jenkinsfile with branch name and build ID as docker build tag params

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
                 sh 'mvn package'
                 script {
                     docker.withRegistry("${env.DOCKER_REGISTRY_URL}", 'docker_registry_credentials') {
-                        def customImage = docker.build('identity-management')
+                        def customImage = docker.build("identity-management:${env.BRANCH_NAME}-${env.BUILD_ID}")
                         customImage.push("${env.BRANCH_NAME}-${env.BUILD_ID}")
                     }
                 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ csrs:
   deleteUrl: "${csrs.serviceUrl}/civilServants/%s/delete"
 
 notifications:
-  service: ${NOTIFICATION_SERVICE_URL:http://localhost:9005}
+  service: ${NOTIFICATION_SERVICE_URL:http://localhost:9006}
   email: "${notifications.service}/notifications/email/"
 
 accountPeriodsInMonths:


### PR DESCRIPTION
Injecting the branch name and build ID into the tag for docker build to avoid implicitly depending on latest and prevent potential reference collisions when two builds execute concurrently