### PR TITLE
LC-332 - update reactivation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+
+### Other ###
+logs/

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-jersey -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jersey</artifactId>
+            <version>2.3.0.RELEASE</version>
+        </dependency>
+
     </dependencies>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,135 +1,135 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>uk.gov.cshr</groupId>
-	<artifactId>identity-management</artifactId>
-	<version>0.0.5</version>
-	<packaging>jar</packaging>
+    <groupId>uk.gov.cshr</groupId>
+    <artifactId>identity-management</artifactId>
+    <version>0.0.5</version>
+    <packaging>jar</packaging>
 
-	<name>Application</name>
-	<description>Identity Management</description>
+    <name>Application</name>
+    <description>Identity Management</description>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.7.RELEASE</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.5.7.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
-		<spring-cloud.version>Edgware.RELEASE</spring-cloud.version>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <spring-cloud.version>Edgware.RELEASE</spring-cloud.version>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-oauth2</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-oauth2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-jwt</artifactId>
-			<version>1.1.1.RELEASE</version>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-jwt</artifactId>
+            <version>1.1.1.RELEASE</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.json/json -->
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20160810</version>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20160810</version>
+        </dependency>
 
-		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.6</version>
-			<scope>provided</scope>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/commons-lang/commons-lang -->
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<version>1.4.199</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.15</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-entitymanager -->
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
-			<version>5.4.2.Final</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-core</artifactId>
-			<version>5.4.2.Final</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-thymeleaf -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
-	</dependencies>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-lang/commons-lang -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>1.4.199</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.15</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-entitymanager -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>5.4.2.Final</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.4.2.Final</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-thymeleaf -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+    </dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 
 </project>

--- a/src/main/java/uk/gov/cshr/Application.java
+++ b/src/main/java/uk/gov/cshr/Application.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -14,19 +13,17 @@ import org.springframework.web.client.RestTemplate;
 @EnableOAuth2Sso
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class Application {
-	@Bean
-	public PasswordEncoder passwordEncoder() {
-		return new BCryptPasswordEncoder();
-	}
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
-	@Bean
-	public RestTemplate restTemplate() {
-		return new RestTemplate();
-	}
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 
-	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
-	}
-
-
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
 }

--- a/src/main/java/uk/gov/cshr/controller/IdentityController.java
+++ b/src/main/java/uk/gov/cshr/controller/IdentityController.java
@@ -1,26 +1,29 @@
 package uk.gov.cshr.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import uk.gov.cshr.domain.Identity;
+import uk.gov.cshr.domain.Reactivation;
 import uk.gov.cshr.domain.Role;
-import uk.gov.cshr.exceptions.ForbiddenException;
+import uk.gov.cshr.exceptions.ResourceNotFoundException;
 import uk.gov.cshr.repository.IdentityRepository;
 import uk.gov.cshr.repository.RoleRepository;
 import uk.gov.cshr.service.Pagination;
+import uk.gov.cshr.service.ReactivationService;
 import uk.gov.cshr.service.security.IdentityDetails;
 import uk.gov.cshr.service.security.IdentityService;
+import uk.gov.cshr.utils.ApplicationConstants;
 
 import java.security.Principal;
 import java.util.ArrayList;
@@ -28,24 +31,37 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+@Slf4j
 @Controller
 @PreAuthorize("hasPermission(returnObject, 'read')")
 public class IdentityController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(IdentityController.class);
-
-    @Autowired
+    public static final String REDIRECT_IDENTITIES_LIST = "redirect:/identities";
+    private static final String IDENTITY_ATTRIBUTE = "identity";
+    private static final String UID_ATTRIBUTE = "uid";
+    private static final String REDIRECT_IDENTITIES_REACTIVATE = "redirect:/identities/reactivate/";
+    private static final String IDENTITY_REACTIVATE_TEMPLATE = "identity/reactivate";
     private IdentityRepository identityRepository;
 
-    @Autowired
     private RoleRepository roleRepository;
 
-    @Autowired
     private IdentityService identityService;
+
+    private ReactivationService reactivationService;
+
+    public IdentityController(IdentityRepository identityRepository,
+                              RoleRepository roleRepository,
+                              IdentityService identityService,
+                              ReactivationService reactivationService) {
+        this.identityRepository = identityRepository;
+        this.roleRepository = roleRepository;
+        this.identityService = identityService;
+        this.reactivationService = reactivationService;
+    }
 
     @GetMapping("/identities")
     public String identities(Model model, Pageable pageable, @RequestParam(value = "query", required = false) String query) {
-        LOGGER.info("Listing all identities");
+        log.debug("Listing all identities");
 
         Page<Identity> pages = query == null || query.isEmpty() ? identityRepository.findAll(pageable) : identityRepository.findAllByEmailContains(pageable, query);
         model.addAttribute("page", pages);
@@ -57,110 +73,163 @@ public class IdentityController {
 
     @GetMapping("/identities/update/{uid}")
     public String identityUpdate(Model model,
-                                 @PathVariable("uid") String uid, Principal principal) {
+                                 @PathVariable(UID_ATTRIBUTE) String uid,
+                                 Principal principal) {
 
-        LOGGER.info("{} editing identity for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
+        log.info("{} editing identity for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
 
         Optional<Identity> optionalIdentity = identityRepository.findFirstByUid(uid);
         Iterable<Role> roles = roleRepository.findAll();
 
         if (optionalIdentity.isPresent()) {
             Identity identity = optionalIdentity.get();
-            model.addAttribute("identity", identity);
+            model.addAttribute(IDENTITY_ATTRIBUTE, identity);
             model.addAttribute("roles", roles);
             return "identity/edit";
         }
 
-        LOGGER.info("No identity found for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
-        return "redirect:/identities";
+        log.info("No identity found for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
+        return REDIRECT_IDENTITIES_LIST;
     }
 
-    @PostMapping("/identities/update")
-    public String identityUpdate(@RequestParam(value = "locked", required = false) Boolean locked, @RequestParam(value = "active", required = false) Boolean active, @RequestParam(value = "roleId", required = false) ArrayList<String> roleId, @RequestParam("uid") String uid, Principal principal) {
+    @PostMapping("/identities/active")
+    public String updateActive(@RequestParam(UID_ATTRIBUTE) String uid,
+                               RedirectAttributes redirectAttributes) {
+        try {
+            Identity identity = identityService.getIdentity(uid);
 
-        // get identity to edit
+            if (identity.isActive()) {
+                identity.setActive(false);
+                identity.setAgencyTokenUid(null);
+                identityRepository.save(identity);
+                redirectAttributes.addFlashAttribute(ApplicationConstants.SUCCESS_ATTRIBUTE, String.format("%s deactivated successfully", identity.getEmail()));
+
+                return REDIRECT_IDENTITIES_LIST;
+            } else {
+                return REDIRECT_IDENTITIES_REACTIVATE + uid;
+            }
+        } catch (ResourceNotFoundException e) {
+            redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.IDENTITY_RESOURCE_NOT_FOUND_ERROR);
+            return REDIRECT_IDENTITIES_LIST;
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
+            return REDIRECT_IDENTITIES_LIST;
+        }
+    }
+
+    @GetMapping("/identities/reactivate/{uid}")
+    public String updateActive(@PathVariable(UID_ATTRIBUTE) String uid,
+                               Model model) {
+        Identity identity = identityService.getIdentity(uid);
+
+        model.addAttribute(IDENTITY_ATTRIBUTE, identity);
+        model.addAttribute(UID_ATTRIBUTE, uid);
+
+        return IDENTITY_REACTIVATE_TEMPLATE;
+    }
+
+    @PostMapping("/identities/reactivate")
+    public String reactivateUser(@RequestParam("uid") String uid,
+                                 RedirectAttributes redirectAttributes) {
+        try {
+            Identity identity = identityService.getIdentity(uid);
+
+            if (!identity.isActive()) {
+                Reactivation reactivationRequest = reactivationService.createReactivationRequest(identity.getEmail());
+                reactivationService.sendReactivationEmail(identity, reactivationRequest);
+                redirectAttributes.addFlashAttribute(ApplicationConstants.SUCCESS_ATTRIBUTE, String.format("Reactivation email verification sent to %s", identity.getEmail()));
+                return REDIRECT_IDENTITIES_LIST;
+            } else {
+                redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.IDENTITY_ALREADY_ACTIVE_ERROR);
+                return REDIRECT_IDENTITIES_LIST;
+            }
+        } catch (ResourceNotFoundException e) {
+            redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.IDENTITY_RESOURCE_NOT_FOUND_ERROR);
+            return REDIRECT_IDENTITIES_LIST;
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
+            return REDIRECT_IDENTITIES_LIST;
+        }
+    }
+
+    @PostMapping("/identities/locked")
+    public String updatedLocked(@RequestParam(UID_ATTRIBUTE) String uid,
+                                RedirectAttributes redirectAttributes) {
+        try {
+            identityService.updateLocked(uid);
+
+            return REDIRECT_IDENTITIES_LIST;
+        } catch (ResourceNotFoundException e) {
+            redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.IDENTITY_RESOURCE_NOT_FOUND_ERROR);
+            return REDIRECT_IDENTITIES_LIST;
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
+            return REDIRECT_IDENTITIES_LIST;
+        }
+    }
+
+
+    @PostMapping("/identities/update")
+    public String identityUpdate(@RequestParam(value = "locked", required = false) Boolean locked,
+                                 @RequestParam(value = "active", required = false) Boolean active,
+                                 @RequestParam(value = "roleId", required = false) ArrayList<String> roleId,
+                                 @RequestParam(UID_ATTRIBUTE) String uid,
+                                 Principal principal,
+                                 RedirectAttributes redirectAttributes) {
+
         Optional<Identity> optionalIdentity = identityRepository.findFirstByUid(uid);
 
         if (optionalIdentity.isPresent()) {
             Identity identity = optionalIdentity.get();
 
             Set<Role> roleSet = new HashSet<>();
-            // create roles from id
             if (roleId != null) {
                 for (String id : roleId) {
                     Optional<Role> optionalRole = roleRepository.findById(Long.parseLong(id));
                     if (optionalRole.isPresent()) {
-                        // got role
                         roleSet.add(optionalRole.get());
                     } else {
-                        LOGGER.info("{} found no role for id {}", ((OAuth2Authentication) principal).getPrincipal(), id);
-                        // do something here , probably go to error page
-                        return "redirect:/identities";
+                        log.info("{} found no role for id {}", ((OAuth2Authentication) principal).getPrincipal(), id);
+                        redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
+                        return REDIRECT_IDENTITIES_LIST;
                     }
                 }
             }
-            // afer this give roleset to identity
-            identity.setRoles(roleSet);
-            // and update  the active property
-            if (active != null) {
-                identity.setActive(active);
-            } else {
-                identity.setActive(false);
-            }
-
-            if (locked != null) {
-                identity.setLocked(locked);
-            } else {
-                identity.setLocked(false);
-            }
-
             identityRepository.save(identity);
 
-            LOGGER.info("{} updated new role {}", ((OAuth2Authentication) principal).getPrincipal(), identity);
+            log.info("{} updated new role {}", ((OAuth2Authentication) principal).getPrincipal(), identity);
         } else {
-            LOGGER.info("{} found no identity for uid {}", ((IdentityDetails) principal).getUsername(), uid);
-            // do something here , probably go to error page
+            log.info("{} found no identity for uid {}", ((IdentityDetails) principal).getUsername(), uid);
+            redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
+            return REDIRECT_IDENTITIES_LIST;
         }
 
-        return "redirect:/identities";
+        return REDIRECT_IDENTITIES_LIST;
     }
 
     @GetMapping("/identities/delete/{uid}")
     @PreAuthorize("hasPermission(returnObject, 'delete')")
-    public String getIdentityDelete(Model model, @PathVariable("uid") String uid, Principal principal) {
-        LOGGER.info("{} deleting identity for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
+    public String getIdentityDelete(Model model, @PathVariable(UID_ATTRIBUTE) String uid, Principal principal) {
+        log.info("{} deleting identity for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
 
         Optional<Identity> optionalIdentity = identityRepository.findFirstByUid(uid);
-        Iterable<Role> roles = roleRepository.findAll();
 
         if (optionalIdentity.isPresent()) {
             Identity identity = optionalIdentity.get();
-            model.addAttribute("identity", identity);
+            model.addAttribute(IDENTITY_ATTRIBUTE, identity);
             return "identity/delete";
         }
 
-        LOGGER.info("No identity found for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
-        return "redirect:/identities";
+        log.info("No identity found for uid {}", ((OAuth2Authentication) principal).getPrincipal(), uid);
+        return REDIRECT_IDENTITIES_LIST;
     }
 
     @Transactional
     @PostMapping("/identities/delete")
     @PreAuthorize("hasPermission(returnObject, 'delete')")
-    public String identityDelete(@RequestParam("uid") String uid) {
+    public String identityDelete(@RequestParam(UID_ATTRIBUTE) String uid) {
         identityService.deleteIdentity(uid);
 
-        return "redirect:/identities";
-    }
-
-    @Transactional
-    @GetMapping("/identities/track")
-    public String identityTrack() {
-        LOGGER.info("Tracking user activity");
-        identityService.trackUserActivity();
-
-        return "redirect:/identities";
+        return REDIRECT_IDENTITIES_LIST;
     }
 }
-
-
-

--- a/src/main/java/uk/gov/cshr/controller/IdentityController.java
+++ b/src/main/java/uk/gov/cshr/controller/IdentityController.java
@@ -102,6 +102,7 @@ public class IdentityController {
                 identity.setActive(false);
                 identity.setAgencyTokenUid(null);
                 identityRepository.save(identity);
+
                 redirectAttributes.addFlashAttribute(ApplicationConstants.SUCCESS_ATTRIBUTE, String.format("%s deactivated successfully", identity.getEmail()));
 
                 return REDIRECT_IDENTITIES_LIST;
@@ -118,8 +119,8 @@ public class IdentityController {
     }
 
     @GetMapping("/identities/reactivate/{uid}")
-    public String updateActive(@PathVariable(UID_ATTRIBUTE) String uid,
-                               Model model) {
+    public String reactivateUser(@PathVariable(UID_ATTRIBUTE) String uid,
+                                 Model model) {
         Identity identity = identityService.getIdentity(uid);
 
         model.addAttribute(IDENTITY_ATTRIBUTE, identity);

--- a/src/main/java/uk/gov/cshr/domain/Identity.java
+++ b/src/main/java/uk/gov/cshr/domain/Identity.java
@@ -1,5 +1,7 @@
 package uk.gov.cshr.domain;
 
+import lombok.Data;
+import lombok.ToString;
 import org.hibernate.validator.constraints.Email;
 
 import javax.persistence.*;
@@ -8,6 +10,8 @@ import java.time.Instant;
 import java.util.Set;
 
 @Entity
+@Data
+@ToString
 public class Identity implements Serializable {
 
     @Id
@@ -32,6 +36,8 @@ public class Identity implements Serializable {
 
     private boolean locked;
 
+    private String agencyTokenUid;
+
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "identity_role",
             joinColumns = @JoinColumn(name = "identity_id", referencedColumnName = "id"),
@@ -42,7 +48,15 @@ public class Identity implements Serializable {
     public Identity() {
     }
 
-    public Identity(String uid, String email, String password, boolean active, boolean locked, Set<Role> roles, Instant lastLoggedIn, boolean deletionNotificationSent) {
+    public Identity(String uid,
+                    String email,
+                    String password,
+                    boolean active,
+                    boolean locked,
+                    Set<Role> roles,
+                    Instant lastLoggedIn,
+                    boolean deletionNotificationSent,
+                    String agencyTokenUid) {
         this.uid = uid;
         this.email = email;
         this.password = password;
@@ -51,83 +65,6 @@ public class Identity implements Serializable {
         this.locked = locked;
         this.lastLoggedIn = lastLoggedIn;
         this.deletionNotificationSent = deletionNotificationSent;
-    }
-
-    public boolean isActive() {
-        return active;
-    }
-
-    public void setActive(Boolean active) {
-        this.active = active;
-    }
-
-    public Set<Role> getRoles() {
-        return roles;
-    }
-
-    public void setRoles(Set<Role> roles) {
-        this.roles = roles;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getUid() {
-        return uid;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public boolean isLocked() {
-        return locked;
-    }
-
-    public void setLocked(boolean locked) {
-        this.locked = locked;
-    }
-
-    public Instant getLastLoggedIn() {
-        return lastLoggedIn;
-    }
-
-    public void setLastLoggedIn(Instant lastLoggedIn) {
-        this.lastLoggedIn = lastLoggedIn;
-    }
-
-    public boolean isDeletionNotificationSent() {
-        return deletionNotificationSent;
-    }
-
-    public void setDeletionNotificationSent(boolean deletionNotificationSent) {
-        this.deletionNotificationSent = deletionNotificationSent;
-    }
-
-    @Override
-    public String toString() {
-        return "Identity{" +
-                "id=" + id +
-                ", uid='" + uid + '\'' +
-                ", email='" + email + '\'' +
-                ", password='" + password + '\'' +
-                ", lastLoggedIn=" + lastLoggedIn +
-                ", active=" + active +
-                ", locked=" + locked +
-                ", roles=" + roles +
-                '}';
+        this.agencyTokenUid = agencyTokenUid;
     }
 }

--- a/src/main/java/uk/gov/cshr/domain/Reactivation.java
+++ b/src/main/java/uk/gov/cshr/domain/Reactivation.java
@@ -1,0 +1,42 @@
+package uk.gov.cshr.domain;
+
+import lombok.Data;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Data
+@ToString
+public class Reactivation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(unique = true, length = 40, nullable = false)
+    private String code;
+
+    @Column(length = 10, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReactivationStatus reactivationStatus;
+
+    @Column(nullable = false)
+    private Date requestedAt;
+
+    private Date reactivatedAt;
+
+    @Column(length = 150, nullable = false)
+    private String email;
+
+    public Reactivation(String code, ReactivationStatus reactivationStatus, Date requestedAt, String email) {
+        this.code = code;
+        this.reactivationStatus = reactivationStatus;
+        this.requestedAt = requestedAt;
+        this.email = email;
+    }
+
+    public Reactivation() {
+    }
+}

--- a/src/main/java/uk/gov/cshr/domain/ReactivationStatus.java
+++ b/src/main/java/uk/gov/cshr/domain/ReactivationStatus.java
@@ -1,0 +1,6 @@
+package uk.gov.cshr.domain;
+
+public enum ReactivationStatus {
+    PENDING,
+    REACTIVATED
+}

--- a/src/main/java/uk/gov/cshr/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/uk/gov/cshr/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.gov.cshr.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Resource not found")
+public class ResourceNotFoundException extends RuntimeException {
+}

--- a/src/main/java/uk/gov/cshr/notifications/service/MessageService.java
+++ b/src/main/java/uk/gov/cshr/notifications/service/MessageService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.cshr.domain.Identity;
 import uk.gov.cshr.domain.Invite;
+import uk.gov.cshr.domain.Reactivation;
 import uk.gov.cshr.notifications.dto.MessageDto;
 import uk.gov.cshr.notifications.dto.factory.MessageDtoFactory;
 
@@ -23,7 +24,11 @@ public class MessageService {
 
     private final String deletedMessageTemplateId;
 
+    private final String reactivationTemplateId;
+
     private final String resetUrl;
+
+    private final String reactivationUrl;
 
     @Value("${invite.url}")
     private String signupUrlFormat;
@@ -32,7 +37,9 @@ public class MessageService {
                           @Value("${govNotify.template.accountDeletion}") String deletionMessageTemplateId,
                           @Value("${govNotify.template.invite}") String invitationMessageTemplateId,
                           @Value("${govNotify.template.accountDeleted}") String deletedMessageTemplateId,
+                          @Value("${govNotify.template.reactivationTemplateId}") String reactivationTemplateId,
                           @Value("${security.oauth2.client.reset-uri}") String resetUrl,
+                          @Value("${security.oauth2.client.reactivation-url}") String reactivationUrl,
                           MessageDtoFactory messageDtoFactory
     ) {
         this.messageDtoFactory = messageDtoFactory;
@@ -40,7 +47,9 @@ public class MessageService {
         this.deletionMessageTemplateId = deletionMessageTemplateId;
         this.invitationMessageTemplateId = invitationMessageTemplateId;
         this.deletedMessageTemplateId = deletedMessageTemplateId;
+        this.reactivationTemplateId = reactivationTemplateId;
         this.resetUrl = resetUrl;
+        this.reactivationUrl = reactivationUrl;
     }
 
     public MessageDto createInvitationnMessage(Invite invite) {
@@ -78,5 +87,14 @@ public class MessageService {
         map.put("learnerName", identity.getEmail());
 
         return messageDtoFactory.create(identity.getEmail(), deletedMessageTemplateId, map);
+    }
+
+    public MessageDto createReactivationMessage(Identity identity, Reactivation reactivation) {
+        Map<String, String> map = new HashMap<>();
+
+        map.put("learnerName", identity.getEmail());
+        map.put("reactivationUrl", String.format(reactivationUrl, reactivation.getCode()));
+
+        return messageDtoFactory.create(identity.getEmail(), reactivationTemplateId, map);
     }
 }

--- a/src/main/java/uk/gov/cshr/repository/ReactivationRepository.java
+++ b/src/main/java/uk/gov/cshr/repository/ReactivationRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.cshr.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.cshr.domain.Reactivation;
+
+@Repository
+public interface ReactivationRepository extends CrudRepository<Reactivation, Long> {
+}

--- a/src/main/java/uk/gov/cshr/service/IdentityReactivationService.java
+++ b/src/main/java/uk/gov/cshr/service/IdentityReactivationService.java
@@ -1,0 +1,31 @@
+package uk.gov.cshr.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.cshr.domain.Identity;
+import uk.gov.cshr.domain.Reactivation;
+import uk.gov.cshr.notifications.service.MessageService;
+import uk.gov.cshr.notifications.service.NotificationService;
+
+@Service
+public class IdentityReactivationService {
+
+    private NotificationService notificationService;
+
+    private MessageService messageService;
+
+    private ReactivationService reactivationService;
+
+    public IdentityReactivationService(NotificationService notificationService,
+                                       MessageService messageService,
+                                       ReactivationService reactivationService) {
+        this.notificationService = notificationService;
+        this.messageService = messageService;
+        this.reactivationService = reactivationService;
+    }
+
+    public boolean sendReactivationEmail(Identity identity) {
+        Reactivation reactivation = reactivationService.createReactivationRequest(identity.getEmail());
+
+        return notificationService.send(messageService.createReactivationMessage(identity, reactivation));
+    }
+}

--- a/src/main/java/uk/gov/cshr/service/ReactivationService.java
+++ b/src/main/java/uk/gov/cshr/service/ReactivationService.java
@@ -1,0 +1,40 @@
+package uk.gov.cshr.service;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.springframework.stereotype.Service;
+import uk.gov.cshr.domain.Identity;
+import uk.gov.cshr.domain.Reactivation;
+import uk.gov.cshr.domain.ReactivationStatus;
+import uk.gov.cshr.notifications.service.MessageService;
+import uk.gov.cshr.notifications.service.NotificationService;
+import uk.gov.cshr.repository.ReactivationRepository;
+
+import java.util.Date;
+
+@Service
+public class ReactivationService {
+
+    private ReactivationRepository reactivationRepository;
+    private MessageService messageService;
+    private NotificationService notificationService;
+
+    public ReactivationService(ReactivationRepository reactivationRepository,
+                               MessageService messageService,
+                               NotificationService notificationService) {
+        this.reactivationRepository = reactivationRepository;
+        this.messageService = messageService;
+        this.notificationService = notificationService;
+    }
+
+    public Reactivation createReactivationRequest(String email) {
+        String code = RandomStringUtils.random(40, true, true);
+
+        Reactivation reactivation = new Reactivation(code, ReactivationStatus.PENDING, new Date(), email);
+
+        return reactivationRepository.save(reactivation);
+    }
+
+    public void sendReactivationEmail(Identity identity, Reactivation reactivation) {
+        notificationService.send(messageService.createReactivationMessage(identity, reactivation));
+    }
+}

--- a/src/main/java/uk/gov/cshr/service/security/IdentityService.java
+++ b/src/main/java/uk/gov/cshr/service/security/IdentityService.java
@@ -107,29 +107,16 @@ public class IdentityService implements UserDetailsService {
                 .orElseThrow(ResourceNotFoundException::new);
     }
 
-    public void updateActive(String uid) {
-        Identity identity = identityRepository.findFirstByUid(uid)
-                .orElseThrow(ResourceNotFoundException::new);
-
-        if (identity.isActive()) {
-            identity.setActive(false);
-            identityRepository.save(identity);
-        } else {
-            identityReactivationService.sendReactivationEmail(identity);
-        }
-    }
-
     public void updateLocked(String uid) {
         Identity identity = identityRepository.findFirstByUid(uid)
                 .orElseThrow(ResourceNotFoundException::new);
 
         if (identity.isLocked()) {
             identity.setLocked(false);
-            identityRepository.save(identity);
         } else {
             identity.setLocked(true);
-            identityRepository.save(identity);
         }
+        identityRepository.save(identity);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/cshr/service/security/IdentityService.java
+++ b/src/main/java/uk/gov/cshr/service/security/IdentityService.java
@@ -14,21 +14,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.cshr.domain.Identity;
-import uk.gov.cshr.domain.Invite;
-import uk.gov.cshr.domain.Role;
+import uk.gov.cshr.exceptions.ResourceNotFoundException;
 import uk.gov.cshr.notifications.service.MessageService;
 import uk.gov.cshr.notifications.service.NotificationService;
 import uk.gov.cshr.repository.IdentityRepository;
-import uk.gov.cshr.service.CSRSService;
-import uk.gov.cshr.service.InviteService;
-import uk.gov.cshr.service.ResetService;
-import uk.gov.cshr.service.TokenService;
+import uk.gov.cshr.service.*;
 import uk.gov.cshr.service.learnerRecord.LearnerRecordService;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -54,6 +49,8 @@ public class IdentityService implements UserDetailsService {
 
     private final MessageService messageService;
 
+    private IdentityReactivationService identityReactivationService;
+
     private final int deactivationMonths;
 
     private final int notificationMonths;
@@ -70,7 +67,8 @@ public class IdentityService implements UserDetailsService {
                            NotificationService notificationService,
                            MessageService messageService,
                            ResetService resetService,
-                           TokenService tokenService) {
+                           TokenService tokenService,
+                           IdentityReactivationService identityReactivationService) {
         this.identityRepository = identityRepository;
         this.passwordEncoder = passwordEncoder;
         this.learnerRecordService = learnerRecordService;
@@ -82,6 +80,7 @@ public class IdentityService implements UserDetailsService {
         this.deletionMonths = deletion;
         this.resetService = resetService;
         this.tokenService = tokenService;
+        this.identityReactivationService = identityReactivationService;
     }
 
     @Autowired
@@ -103,20 +102,34 @@ public class IdentityService implements UserDetailsService {
         return identityRepository.existsByEmail(email);
     }
 
-    public void createIdentityFromInviteCode(String code, String password) {
-        Invite invite = inviteService.findByCode(code);
-
-        Set<Role> newRoles = new HashSet<>(invite.getForRoles());
-        Identity identity = new Identity(UUID.randomUUID().toString(), invite.getForEmail(), passwordEncoder.encode(password), true, false, newRoles, Instant.now(), false);
-        identityRepository.save(identity);
-
-        LOGGER.info("New identity {} successfully created", identity.getEmail());
+    public Identity getIdentity(String uid) {
+        return identityRepository.findFirstByUid(uid)
+                .orElseThrow(ResourceNotFoundException::new);
     }
 
-    public void lockIdentity(String email) {
-        Identity identity = identityRepository.findFirstByActiveTrueAndEmailEquals(email);
-        identity.setLocked(true);
-        identityRepository.save(identity);
+    public void updateActive(String uid) {
+        Identity identity = identityRepository.findFirstByUid(uid)
+                .orElseThrow(ResourceNotFoundException::new);
+
+        if (identity.isActive()) {
+            identity.setActive(false);
+            identityRepository.save(identity);
+        } else {
+            identityReactivationService.sendReactivationEmail(identity);
+        }
+    }
+
+    public void updateLocked(String uid) {
+        Identity identity = identityRepository.findFirstByUid(uid)
+                .orElseThrow(ResourceNotFoundException::new);
+
+        if (identity.isLocked()) {
+            identity.setLocked(false);
+            identityRepository.save(identity);
+        } else {
+            identity.setLocked(true);
+            identityRepository.save(identity);
+        }
     }
 
     @Transactional

--- a/src/main/java/uk/gov/cshr/utils/ApplicationConstants.java
+++ b/src/main/java/uk/gov/cshr/utils/ApplicationConstants.java
@@ -1,0 +1,10 @@
+package uk.gov.cshr.utils;
+
+public class ApplicationConstants {
+
+    public static final String STATUS_ATTRIBUTE = "status";
+    public static final String IDENTITY_RESOURCE_NOT_FOUND_ERROR = "The Identity could not be updated because it could not be found";
+    public static final String SYSTEM_ERROR = "The system encountered an error, please try again later";
+    public static final String SUCCESS_ATTRIBUTE = "success";
+    public static final String IDENTITY_ALREADY_ACTIVE_ERROR = "The Identity could not be reactivated because they are already active";
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   thymeleaf:
     cache: false
@@ -9,6 +8,15 @@ spring:
 server:
   port: 8081
   context-path: /mgmt
+
+logging:
+  pattern:
+    console: "%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+  level:
+    root: ${ROOT_LOGGING_LEVEL:INFO}
+    org.springframework: INFO
+    org.apache: INFO
+    org.hibernate: INFO
 
 security:
   oauth2:
@@ -22,7 +30,7 @@ security:
       access-token-uri: ${OAUTH_URL:http://localhost:8080}/oauth/token
       user-authorization-uri: ${OAUTH_URL:http://localhost:8080}/oauth/authorize
       reset-uri: ${OAUTH_URL:http://localhost:8080}/reset
-
+      reactivation-url: "${OAUTH_URL:http://localhost:8080}/account/reactivate/%s"
 
 invite:
   url: ${INVITE_SIGNUP_URL:http://localhost:8080/signup/%s}
@@ -51,14 +59,15 @@ govNotify:
     accountSuspension: ${GOV_NOTIFY_ACCOUNT_SUSPENSION_TEMPLATE_ID:de47fe22-96fc-448f-a3f0-d105e9f0e0e6}
     accountDeletion: ${GOV_NOTIFY_ACCOUNT_DELETION_TEMPLATE_ID:5830199c-a524-458c-a630-c1b64734cf18}
     accountDeleted: ${GOV_NOTIFY_ACCOUNT_DELETED_TEMPLATE_ID:f8aa74fb-eaaf-4e4e-a6fc-f6a9a703b686}
+    reactivationTemplateId: ${GOV_NOTIFY_REACTIVATION_TEMPLATE_ID:abfb2e5f-3905-4817-b041-c53afd1eb3e5}
 
 ---
 spring:
-  profiles: production
+  profiles: test, production
   thymeleaf:
     cache: true
   datasource:
-    url: ${DATASOURCE:jdbc:mysql://localhost:3306/oauth2?user=root&password=password&useSSL=false}
+    url: ${DATASOURCE:jdbc:mysql://localhost:3306/identity?user=root&password=password&useSSL=false}
     platform: mysql
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOGS" value="./logs" />
+
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1.}): %msg%n%throwable
+            </Pattern>
+        </layout>
+    </appender>
+
+    <appender name="RollingFile"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS}/spring-boot-logger.log</file>
+        <encoder
+                class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+        </encoder>
+
+        <rollingPolicy
+                class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- rollover daily and when the file reaches 10 MegaBytes -->
+            <fileNamePattern>${LOGS}/archived/spring-boot-logger-%d{yyyy-MM-dd}.%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <!-- LOG everything at INFO level -->
+    <root level="info">
+        <appender-ref ref="RollingFile" />
+        <appender-ref ref="Console" />
+    </root>
+
+    <!-- LOG "uk.gov*" at TRACE level -->
+    <logger name="uk.gov" level="trace" additivity="false">
+        <appender-ref ref="RollingFile" />
+        <appender-ref ref="Console" />
+    </logger>
+
+</configuration>

--- a/src/main/resources/templates/identity/edit.html
+++ b/src/main/resources/templates/identity/edit.html
@@ -6,25 +6,43 @@
 </head>
 <body>
 <section layout:fragment="content">
-    <h4 th:text="${'Update Identity - ' + identity.email}"></h4>
+    <a href="#" class="btn btn-link">Back</a>
+
+    <h1 th:text="${'Update Identity - ' + identity.email}"></h1>
+    <h2>Account status</h2>
+    <div class="container">
+        <form th:action="@{/identities/active}" method="POST" th:object="${identity}">
+            <div class="row" style="padding-bottom: 1%">
+                <div class="col-sm-8" th:text="${identity.active} ? 'Account Active: Yes' : 'Account Active: No'"></div>
+                <div class="col-sm-4">
+                    <button type="submit" class="btn btn-primary"
+                            th:text="${identity.active} ? 'Deactivate user' : 'Request reactivation'"></button>
+                </div>
+            </div>
+            <input type="hidden" th:field="*{uid}"/>
+        </form>
+        <form th:action="@{/identities/locked}" method="POST" th:object="${identity}">
+            <div class="row" style="padding-bottom: 1%">
+                <div class="col-sm-8" th:text="${identity.locked} ? 'Account Locked: Yes' : 'Account Locked: No'"></div>
+                <div class="col-sm-4">
+                    <button type="submit" class="btn btn-primary"
+                            th:text="${identity.locked} ? 'Unlock user' : 'Lock user'"></button>
+                </div>
+            </div>
+            <input type="hidden" th:field="*{uid}"/>
+        </form>
+    </div>
+
+    <h2>Update roles</h2>
     <form autocomplete="off" action="#" th:action="@{/identities/update}" th:object="${identity}" method="POST">
-        <div class="form-check">
-            <input id="active" class="form-check-input" type="checkbox" th:field="*{active}" th:checked="${identity.active}"/>
-            <label for="active" class="form-check-label" th:for="active">Active</label>
-        </div>
-        <div class="form-check">
-            <input id="lock" class="form-check-input" type="checkbox" th:field="*{locked}" th:checked="${identity.locked}"/>
-            <label for="lock" class="form-check-label" th:for="locked">Locked</label>
-        </div>
         <div class="form-group">
-            <label for="roleId">Roles</label>
             <select class="form-control" multiple="multiple" name="roleId" id="roleId" size="25" style="height: 100%;">
                 <option th:each="role : ${roles}" th:value="${role.id}" th:text="${role.name}"
                         th:selected="${identity.getRoles().contains(role)}"></option>
             </select>
         </div>
         <input type="hidden" th:field="*{uid}"/>
-        <button type="submit" class="btn btn-primary">Update</button>
+        <button type="submit" class="btn btn-primary">Update Roles</button>
     </form>
 </section>
 </body>

--- a/src/main/resources/templates/identity/edit.html
+++ b/src/main/resources/templates/identity/edit.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <section layout:fragment="content">
-    <a href="#" class="btn btn-link">Back</a>
+    <a href="/mgmt/identities" class="btn btn-link">Back</a>
 
     <h1 th:text="${'Update Identity - ' + identity.email}"></h1>
     <h2>Account status</h2>

--- a/src/main/resources/templates/identity/list.html
+++ b/src/main/resources/templates/identity/list.html
@@ -6,6 +6,14 @@
 </head>
 <body>
 <section layout:fragment="content">
+    <div th:if="${status}" class="alert alert-danger" role="alert">
+        <h4 class="alert-heading">There was a problem</h4>
+        <p th:text="${status}">status ...</p>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    <div th:if="${success}" class="alert alert-success" role="alert" th:text="${success}">success</div>
     <form autocomplete="off" action="#" th:action="@{/identities}" method="get">
         <div class="form-row">
             <div class="col-10">

--- a/src/main/resources/templates/identity/reactivate.html
+++ b/src/main/resources/templates/identity/reactivate.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorator="layout">
+<head>
+    <title th:text="'Reactivate Identity - ' + ${identity.email}"></title>
+</head>
+<body>
+<section layout:fragment="content">
+    <h4 th:text="'Reactivate identity - ' + ${identity.email}"></h4>
+    <div class="alert alert-warning" role="alert">
+        Are you sure to request reactivation? Once requested, the user will receive an verification email to complete
+        the process.
+    </div>
+
+    <form autocomplete="off" action="#" th:action="@{/identities/reactivate}" th:object="${identity}" method="post">
+        <div style="padding-bottom: 1%">
+            <input type="hidden" th:field="*{uid}"/>
+            <button type="submit" class="btn btn-success">Send reactivation</button>
+        </div>
+    </form>
+    <a class="btn btn-danger" th:href="@{|/identities/update/${identity.uid}|}" role="button">Cancel</a>
+
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/identity/reactivate.html
+++ b/src/main/resources/templates/identity/reactivate.html
@@ -8,7 +8,8 @@
 <section layout:fragment="content">
     <h4 th:text="'Reactivate identity - ' + ${identity.email}"></h4>
     <div class="alert alert-warning" role="alert">
-        Are you sure to request reactivation? Once requested, the user will receive an verification email to complete
+        Are you sure want to request reactivation for this user? Once requested, the user will receive an verification
+        email to complete
         the process.
     </div>
 

--- a/src/test/java/uk/gov/cshr/config/ResourceServerConfiguration.java
+++ b/src/test/java/uk/gov/cshr/config/ResourceServerConfiguration.java
@@ -1,0 +1,15 @@
+package uk.gov.cshr.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
+
+@Configuration
+@EnableResourceServer
+public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {
+    @Override
+    public void configure(ResourceServerSecurityConfigurer security) throws Exception {
+        security.stateless(false);
+    }
+}

--- a/src/test/java/uk/gov/cshr/controller/IdentityControllerTest.java
+++ b/src/test/java/uk/gov/cshr/controller/IdentityControllerTest.java
@@ -1,0 +1,63 @@
+package uk.gov.cshr.controller;
+
+import org.glassfish.jersey.servlet.WebConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.cshr.repository.IdentityRepository;
+import uk.gov.cshr.repository.RoleRepository;
+import uk.gov.cshr.service.ReactivationService;
+import uk.gov.cshr.service.security.IdentityService;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest(IdentityController.class)
+@WithMockUser(username = "user")
+@ContextConfiguration(classes = {WebConfig.class, IdentityController.class})
+@EnableSpringDataWebSupport
+public class IdentityControllerTest {
+
+    private static final String UID = "UID";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private IdentityRepository identityRepository;
+
+    @MockBean
+    private RoleRepository roleRepository;
+
+    @MockBean
+    private IdentityService identityService;
+
+    @MockBean
+    private ReactivationService reactivationService;
+
+    @Test
+    public void updateActive() throws Exception {
+        doNothing().when(identityService).updateActive(UID);
+
+        mockMvc.perform(
+                post("/identities/active")
+                        .with(csrf())
+                        .accept(APPLICATION_JSON).param("uid", UID))
+                .andDo(print())
+                .andExpect(model().attributeDoesNotExist("status"))
+                .andExpect(status().is3xxRedirection());
+    }
+}

--- a/src/test/java/uk/gov/cshr/notifications/service/MessageServiceTest.java
+++ b/src/test/java/uk/gov/cshr/notifications/service/MessageServiceTest.java
@@ -1,0 +1,80 @@
+package uk.gov.cshr.notifications.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Value;
+import uk.gov.cshr.domain.Identity;
+import uk.gov.cshr.domain.Reactivation;
+import uk.gov.cshr.notifications.dto.factory.MessageDtoFactory;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class MessageServiceTest {
+
+    private static final String EMAIL = "test@example.com";
+    private static final String CODE = "code";
+    @Mock
+    private MessageDtoFactory messageDtoFactory;
+
+    private String suspensionMessageTemplateId = "suspensionMessageTemplateId";
+
+    private String deletionMessageTemplateId = "deletionMessageTemplateId";
+
+    private String invitationMessageTemplateId = "invitationMessageTemplateId";
+
+    private String deletedMessageTemplateId = "deletedMessageTemplateId";
+
+    private String reactivationTemplateId = "reactivationTemplateId";
+
+    private String resetUrl = "resetUrl";
+    private String reactivationUrl = "www.example.com/reactivate/";
+
+    @Value("${invite.url}")
+    private String signupUrlFormat;
+
+    private MessageService messageService;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        this.messageService = new MessageService(
+                suspensionMessageTemplateId,
+                deletionMessageTemplateId,
+                invitationMessageTemplateId,
+                deletedMessageTemplateId,
+                reactivationTemplateId,
+                resetUrl,
+                reactivationUrl,
+                messageDtoFactory);
+    }
+
+    @Test
+    public void createReactivationMessage() {
+        Reactivation reactivation = new Reactivation();
+        reactivation.setCode(CODE);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("learnerName", EMAIL);
+        map.put("reactivationUrl", String.format(reactivationUrl, CODE));
+
+        Identity identity = new Identity("uid",
+                EMAIL,
+                "password",
+                true,
+                false,
+                null,
+                Instant.now(),
+                false, null);
+
+        messageService.createReactivationMessage(identity, reactivation);
+
+        verify(messageDtoFactory, times(1)).create(EMAIL, reactivationTemplateId, map);
+    }
+}

--- a/src/test/java/uk/gov/cshr/service/IdentityReactivationServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/IdentityReactivationServiceTest.java
@@ -1,0 +1,53 @@
+package uk.gov.cshr.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.cshr.domain.Identity;
+import uk.gov.cshr.domain.Reactivation;
+import uk.gov.cshr.notifications.dto.MessageDto;
+import uk.gov.cshr.notifications.service.MessageService;
+import uk.gov.cshr.notifications.service.NotificationService;
+
+import java.time.Instant;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdentityReactivationServiceTest {
+
+    private static final String EMAIL = "test@example.com";
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private MessageService messageService;
+
+    @Mock
+    private ReactivationService reactivationService;
+
+    @InjectMocks
+    private IdentityReactivationService identityReactivationService;
+
+    @Test
+    public void shouldSendReactivationEmail() {
+        Identity identity = new Identity("uid",
+                EMAIL,
+                "password",
+                true,
+                false,
+                null,
+                Instant.now(),
+                false, null);
+        Reactivation reactivation = new Reactivation();
+        MessageDto messageDto = new MessageDto();
+
+        when(reactivationService.createReactivationRequest(EMAIL)).thenReturn(reactivation);
+        when(messageService.createReactivationMessage(identity, reactivation)).thenReturn(messageDto);
+        when(notificationService.send(messageDto)).thenReturn(true);
+        assertTrue(identityReactivationService.sendReactivationEmail(identity));
+    }
+}

--- a/src/test/java/uk/gov/cshr/service/ReactivationServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/ReactivationServiceTest.java
@@ -1,0 +1,34 @@
+package uk.gov.cshr.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.cshr.domain.Reactivation;
+import uk.gov.cshr.repository.ReactivationRepository;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReactivationServiceTest {
+
+    private static final String EMAIL = "test@example.com";
+
+    @Mock
+    private ReactivationRepository reactivationRepository;
+
+    @InjectMocks
+    private ReactivationService reactivationService;
+
+    @Test
+    public void createReactivationRequest() {
+        Reactivation reactivation = new Reactivation();
+
+        when(reactivationRepository.save(any(Reactivation.class))).thenReturn(reactivation);
+
+        assertEquals(reactivationService.createReactivationRequest(EMAIL), reactivation);
+    }
+}

--- a/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
@@ -3,6 +3,8 @@ package uk.gov.cshr.service.security;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,12 +18,14 @@ import uk.gov.cshr.service.learnerRecord.LearnerRecordService;
 
 import java.util.Optional;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IdentityServiceTest {
 
     private static final String UID = "UID";
+    private static final Long ID = 1L;
     @Mock
     private IdentityRepository identityRepository;
 
@@ -52,6 +56,9 @@ public class IdentityServiceTest {
     @Mock
     private IdentityReactivationService identityReactivationService;
 
+    @Captor
+    private ArgumentCaptor<Identity> identityArgumentCaptor;
+
     private int deactivationMonths = 10;
 
     private int notificationMonths = 20;
@@ -74,45 +81,69 @@ public class IdentityServiceTest {
                 resetService,
                 tokenService,
                 identityReactivationService);
+
+        identityArgumentCaptor = ArgumentCaptor.forClass(Identity.class);
     }
 
     @Test
-    public void shouldSetActiveToFalseIfActive() {
+    public void shouldGetIdentity() {
         Identity identity = new Identity();
-        identity.setActive(true);
+        identity.setId(ID);
+
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.of(identity));
+
+        Identity actualIdentity = identityService.getIdentity(UID);
+
+        assertEquals(ID, actualIdentity.getId());
+    }
+
+    @Test(expected = ResourceNotFoundException.class)
+    public void shouldThrowExceptionIfIdentityNotFound() {
+        doThrow(new ResourceNotFoundException()).when(identityRepository).findFirstByUid(UID);
+
+        identityService.getIdentity(UID);
+    }
+
+    @Test
+    public void shouldSetLockedToFalseIfLockedIsTrue() {
+        Identity identity = new Identity();
+        identity.setLocked(true);
 
         when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.of(identity));
 
         when(identityRepository.save(identity)).thenReturn(identity);
 
-        identityService.updateActive(UID);
+        identityService.updateLocked(UID);
 
-        verify(identityReactivationService, times(0)).sendReactivationEmail(any(Identity.class));
+        verify(identityRepository).save(identityArgumentCaptor.capture());
+
+        Identity actualIdentity = identityArgumentCaptor.getValue();
+        assertEquals(false, actualIdentity.isLocked());
     }
 
     @Test
-    public void shouldCallReactivationServiceIfActiveIsFalse() {
+    public void shouldSetLockedToTrueIfLockedIsFalse() {
         Identity identity = new Identity();
-        identity.setActive(false);
+        identity.setLocked(false);
 
         when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.of(identity));
 
+        when(identityRepository.save(identity)).thenReturn(identity);
 
-        identityService.updateActive(UID);
+        identityService.updateLocked(UID);
 
-        verify(identityRepository, times(0)).save(any(Identity.class));
+        verify(identityRepository).save(identityArgumentCaptor.capture());
 
-        verify(identityReactivationService, times(1)).sendReactivationEmail(identity);
+        Identity actualIdentity = identityArgumentCaptor.getValue();
+        assertEquals(true, actualIdentity.isLocked());
     }
 
     @Test(expected = ResourceNotFoundException.class)
-    public void shouldThrowResourceNotFoundIfIdentityDoesNotExist() {
+    public void shouldThrowResourceNotFoundIfIdentityDoesNotExistWhenUpdatedLocked() {
         when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.empty());
 
-        identityService.updateActive(UID);
+        identityService.updateLocked(UID);
 
         verify(identityRepository, times(0)).save(any(Identity.class));
-
-        verify(identityReactivationService, times(0)).sendReactivationEmail(any(Identity.class));
     }
 }

--- a/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
@@ -1,0 +1,118 @@
+package uk.gov.cshr.service.security;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import uk.gov.cshr.domain.Identity;
+import uk.gov.cshr.exceptions.ResourceNotFoundException;
+import uk.gov.cshr.notifications.service.MessageService;
+import uk.gov.cshr.notifications.service.NotificationService;
+import uk.gov.cshr.repository.IdentityRepository;
+import uk.gov.cshr.service.*;
+import uk.gov.cshr.service.learnerRecord.LearnerRecordService;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdentityServiceTest {
+
+    private static final String UID = "UID";
+    @Mock
+    private IdentityRepository identityRepository;
+
+    @Mock
+    private InviteService inviteService;
+
+    @Mock
+    private ResetService resetService;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private LearnerRecordService learnerRecordService;
+
+    @Mock
+    private CSRSService csrsService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private MessageService messageService;
+
+    @Mock
+    private IdentityReactivationService identityReactivationService;
+
+    private int deactivationMonths = 10;
+
+    private int notificationMonths = 20;
+
+    private int deletionMonths = 36;
+
+    private IdentityService identityService;
+
+    @Before
+    public void setUp() throws Exception {
+        identityService = new IdentityService(deactivationMonths,
+                notificationMonths,
+                deletionMonths,
+                identityRepository,
+                passwordEncoder,
+                learnerRecordService,
+                csrsService,
+                notificationService,
+                messageService,
+                resetService,
+                tokenService,
+                identityReactivationService);
+    }
+
+    @Test
+    public void shouldSetActiveToFalseIfActive() {
+        Identity identity = new Identity();
+        identity.setActive(true);
+
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.of(identity));
+
+        when(identityRepository.save(identity)).thenReturn(identity);
+
+        identityService.updateActive(UID);
+
+        verify(identityReactivationService, times(0)).sendReactivationEmail(any(Identity.class));
+    }
+
+    @Test
+    public void shouldCallReactivationServiceIfActiveIsFalse() {
+        Identity identity = new Identity();
+        identity.setActive(false);
+
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.of(identity));
+
+
+        identityService.updateActive(UID);
+
+        verify(identityRepository, times(0)).save(any(Identity.class));
+
+        verify(identityReactivationService, times(1)).sendReactivationEmail(identity);
+    }
+
+    @Test(expected = ResourceNotFoundException.class)
+    public void shouldThrowResourceNotFoundIfIdentityDoesNotExist() {
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.empty());
+
+        identityService.updateActive(UID);
+
+        verify(identityRepository, times(0)).save(any(Identity.class));
+
+        verify(identityReactivationService, times(0)).sendReactivationEmail(any(Identity.class));
+    }
+}


### PR DESCRIPTION
_Also needed is the following PR on identity-service: https://github.com/Civil-Service-Human-Resources/identity-service/pull/163_

New service and data classes for updates to reactivation. When a user submits a reactivation, a reactivation object will be created and an email will be sent to the user to confirm the reactivation. This allows reactivation requests to be sent through the agency token validation if neccessary.

- new sent request reactivation flow for reactivating a user
- new gov notify template id for reactivation
- updates to templates and controllers for update identity
- new custom exceptions