### PR TITLE
hotfix: resolving roles update issue

### DIFF
--- a/src/main/java/uk/gov/cshr/controller/IdentityController.java
+++ b/src/main/java/uk/gov/cshr/controller/IdentityController.java
@@ -176,22 +176,20 @@ public class IdentityController {
 
         Optional<Identity> optionalIdentity = identityRepository.findFirstByUid(uid);
 
-        if (optionalIdentity.isPresent()) {
+        if (optionalIdentity.isPresent() && roleId != null) {
             Identity identity = optionalIdentity.get();
 
             Set<Role> roleSet = new HashSet<>();
-            if (roleId != null) {
-                for (String id : roleId) {
-                    Optional<Role> optionalRole = roleRepository.findById(Long.parseLong(id));
-                    if (optionalRole.isPresent()) {
-                        roleSet.add(optionalRole.get());
-                    } else {
-                        redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
-                        return REDIRECT_IDENTITIES_LIST;
-                    }
+            for (String id : roleId) {
+                Optional<Role> optionalRole = roleRepository.findById(Long.parseLong(id));
+                if (optionalRole.isPresent()) {
+                    roleSet.add(optionalRole.get());
+                } else {
+                    redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
+                    return REDIRECT_IDENTITIES_LIST;
                 }
-                identity.setRoles(roleSet);
             }
+            identity.setRoles(roleSet);
             identityRepository.save(identity);
             identityService.clearUserTokens(identity);
         } else {

--- a/src/main/java/uk/gov/cshr/controller/IdentityController.java
+++ b/src/main/java/uk/gov/cshr/controller/IdentityController.java
@@ -21,7 +21,6 @@ import uk.gov.cshr.repository.IdentityRepository;
 import uk.gov.cshr.repository.RoleRepository;
 import uk.gov.cshr.service.Pagination;
 import uk.gov.cshr.service.ReactivationService;
-import uk.gov.cshr.service.security.IdentityDetails;
 import uk.gov.cshr.service.security.IdentityService;
 import uk.gov.cshr.utils.ApplicationConstants;
 
@@ -171,11 +170,8 @@ public class IdentityController {
 
 
     @PostMapping("/identities/update")
-    public String identityUpdate(@RequestParam(value = "locked", required = false) Boolean locked,
-                                 @RequestParam(value = "active", required = false) Boolean active,
-                                 @RequestParam(value = "roleId", required = false) ArrayList<String> roleId,
+    public String identityUpdate(@RequestParam(value = "roleId", required = false) ArrayList<String> roleId,
                                  @RequestParam(UID_ATTRIBUTE) String uid,
-                                 Principal principal,
                                  RedirectAttributes redirectAttributes) {
 
         Optional<Identity> optionalIdentity = identityRepository.findFirstByUid(uid);
@@ -190,18 +186,15 @@ public class IdentityController {
                     if (optionalRole.isPresent()) {
                         roleSet.add(optionalRole.get());
                     } else {
-                        log.info("{} found no role for id {}", ((OAuth2Authentication) principal).getPrincipal(), id);
                         redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
                         return REDIRECT_IDENTITIES_LIST;
                     }
                 }
+                identity.setRoles(roleSet);
             }
             identityRepository.save(identity);
             identityService.clearUserTokens(identity);
-
-            log.info("{} updated new role {}", ((OAuth2Authentication) principal).getPrincipal(), identity);
         } else {
-            log.info("{} found no identity for uid {}", ((IdentityDetails) principal).getUsername(), uid);
             redirectAttributes.addFlashAttribute(ApplicationConstants.STATUS_ATTRIBUTE, ApplicationConstants.SYSTEM_ERROR);
             return REDIRECT_IDENTITIES_LIST;
         }

--- a/src/test/java/uk/gov/cshr/controller/IdentityControllerTest.java
+++ b/src/test/java/uk/gov/cshr/controller/IdentityControllerTest.java
@@ -385,7 +385,7 @@ public class IdentityControllerTest {
         identity.setEmail(EMAIL);
         identity.setAgencyTokenUid(AGENCY_UID);
         identity.setRoles(null);
-        
+
         when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.empty());
 
         mockMvc.perform(
@@ -395,6 +395,27 @@ public class IdentityControllerTest {
                         .accept(APPLICATION_JSON).param("roleId", "1")
                         .accept(APPLICATION_JSON).param("roleId", "2")
                         .accept(APPLICATION_JSON).param("roleId", "3"))
+                .andExpect(flash().attribute("status", ApplicationConstants.SYSTEM_ERROR))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(IDENTITIES_URL));
+
+        verify(identityRepository, times(0)).save(any(Identity.class));
+    }
+
+    @Test
+    public void updateIdentityRolesShouldRedirectIfRoleParamNotPresent() throws Exception {
+        Identity identity = new Identity();
+        identity.setActive(true);
+        identity.setEmail(EMAIL);
+        identity.setAgencyTokenUid(AGENCY_UID);
+        identity.setRoles(null);
+
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(
+                post("/identities/update/")
+                        .with(csrf())
+                        .accept(APPLICATION_JSON).param("uid", UID))
                 .andExpect(flash().attribute("status", ApplicationConstants.SYSTEM_ERROR))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl(IDENTITIES_URL));

--- a/src/test/java/uk/gov/cshr/controller/IdentityControllerTest.java
+++ b/src/test/java/uk/gov/cshr/controller/IdentityControllerTest.java
@@ -16,12 +16,18 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.cshr.domain.Identity;
 import uk.gov.cshr.domain.Reactivation;
+import uk.gov.cshr.domain.Role;
 import uk.gov.cshr.exceptions.ResourceNotFoundException;
 import uk.gov.cshr.repository.IdentityRepository;
 import uk.gov.cshr.repository.RoleRepository;
 import uk.gov.cshr.service.ReactivationService;
 import uk.gov.cshr.service.security.IdentityService;
 import uk.gov.cshr.utils.ApplicationConstants;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
@@ -303,5 +309,96 @@ public class IdentityControllerTest {
                 .andExpect(flash().attribute("status", ApplicationConstants.SYSTEM_ERROR))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl(IDENTITIES_URL));
+    }
+
+    @Test
+    public void updateIdentityRoles() throws Exception {
+        Identity identity = new Identity();
+        identity.setActive(true);
+        identity.setEmail(EMAIL);
+        identity.setAgencyTokenUid(AGENCY_UID);
+        identity.setRoles(null);
+
+        Role learnerRole = new Role("LEARNER", "LEARNER DESC");
+        Role adminRole = new Role("ADMIN", "ADMIN DESC");
+
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.of(identity));
+        when(roleRepository.findById(1)).thenReturn(Optional.of(learnerRole));
+        when(roleRepository.findById(2)).thenReturn(Optional.of(adminRole));
+        doNothing().when(identityService).clearUserTokens(identity);
+
+        mockMvc.perform(
+                post("/identities/update/")
+                        .with(csrf())
+                        .accept(APPLICATION_JSON).param("uid", UID)
+                        .accept(APPLICATION_JSON).param("roleId", "1")
+                        .accept(APPLICATION_JSON).param("roleId", "2"))
+                .andExpect(model().attributeDoesNotExist("status"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(IDENTITIES_URL));
+
+        verify(identityRepository).save(identityArgumentCaptor.capture());
+
+        Set<Role> rolesSet = new HashSet<>(Arrays.asList(learnerRole, adminRole));
+
+        Identity actualIdentity = identityArgumentCaptor.getValue();
+        assertEquals(true, actualIdentity.isActive());
+        assertEquals(AGENCY_UID, actualIdentity.getAgencyTokenUid());
+        assertEquals(rolesSet, actualIdentity.getRoles());
+    }
+
+    @Test
+    public void updateIdentityRolesShouldRedirectIfRoleNotPresent() throws Exception {
+        Identity identity = new Identity();
+        identity.setActive(true);
+        identity.setEmail(EMAIL);
+        identity.setAgencyTokenUid(AGENCY_UID);
+        identity.setRoles(null);
+
+        Role learnerRole = new Role("LEARNER", "LEARNER DESC");
+        Role adminRole = new Role("ADMIN", "ADMIN DESC");
+
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.of(identity));
+        when(roleRepository.findById(1)).thenReturn(Optional.of(learnerRole));
+        when(roleRepository.findById(2)).thenReturn(Optional.of(adminRole));
+        when(roleRepository.findById(3)).thenReturn(Optional.empty());
+        doNothing().when(identityService).clearUserTokens(identity);
+
+        mockMvc.perform(
+                post("/identities/update/")
+                        .with(csrf())
+                        .accept(APPLICATION_JSON).param("uid", UID)
+                        .accept(APPLICATION_JSON).param("roleId", "1")
+                        .accept(APPLICATION_JSON).param("roleId", "2")
+                        .accept(APPLICATION_JSON).param("roleId", "3"))
+                .andExpect(flash().attribute("status", ApplicationConstants.SYSTEM_ERROR))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(IDENTITIES_URL));
+
+        verify(identityRepository, times(0)).save(any(Identity.class));
+    }
+
+    @Test
+    public void updateIdentityRolesShouldRedirectIfIdentityNotPresent() throws Exception {
+        Identity identity = new Identity();
+        identity.setActive(true);
+        identity.setEmail(EMAIL);
+        identity.setAgencyTokenUid(AGENCY_UID);
+        identity.setRoles(null);
+        
+        when(identityRepository.findFirstByUid(UID)).thenReturn(Optional.empty());
+
+        mockMvc.perform(
+                post("/identities/update/")
+                        .with(csrf())
+                        .accept(APPLICATION_JSON).param("uid", UID)
+                        .accept(APPLICATION_JSON).param("roleId", "1")
+                        .accept(APPLICATION_JSON).param("roleId", "2")
+                        .accept(APPLICATION_JSON).param("roleId", "3"))
+                .andExpect(flash().attribute("status", ApplicationConstants.SYSTEM_ERROR))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(IDENTITIES_URL));
+
+        verify(identityRepository, times(0)).save(any(Identity.class));
     }
 }


### PR DESCRIPTION
Managed to remove the 'updating roles' logic during a previous refactor. Reintroducing and adding tests.

Removing excess logging statements and redundant http post parameters.