### PR TITLE
LC-666: disable scheduled job

### DIFF
--- a/src/main/java/uk/gov/cshr/service/scheduler/Scheduler.java
+++ b/src/main/java/uk/gov/cshr/service/scheduler/Scheduler.java
@@ -23,7 +23,9 @@ public class Scheduler {
     public void trackUserActivity() {
         LOGGER.info("Executing trackUserActivity at {}", dateFormat.format(new Date()));
 
-        identityService.trackUserActivity();
+        LOGGER.info("Skipping trackUserActivity at {}", dateFormat.format(new Date()));
+
+//        identityService.trackUserActivity();
 
         LOGGER.info("trackUserActivity complete at {}", dateFormat.format(new Date()));
     }


### PR DESCRIPTION
Issue found with the data retention job in that it is taking too long to complete, which can cause db timeouts, subsequently causing the whole transaction to roll-back. Temporarily commenting out the job to disable while a permanent fix is developed.