### PR TITLE
Lc 666 data retention job improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+
+logs/**

--- a/src/main/java/uk/gov/cshr/Application.java
+++ b/src/main/java/uk/gov/cshr/Application.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/src/main/java/uk/gov/cshr/domain/Identity.java
+++ b/src/main/java/uk/gov/cshr/domain/Identity.java
@@ -1,5 +1,6 @@
 package uk.gov.cshr.domain;
 
+import lombok.AllArgsConstructor;
 import org.hibernate.validator.constraints.Email;
 
 import javax.persistence.*;
@@ -8,6 +9,7 @@ import java.time.Instant;
 import java.util.Set;
 
 @Entity
+@AllArgsConstructor
 public class Identity implements Serializable {
 
     @Id
@@ -32,7 +34,7 @@ public class Identity implements Serializable {
 
     private boolean locked;
 
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "identity_role",
             joinColumns = @JoinColumn(name = "identity_id", referencedColumnName = "id"),
             inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id")

--- a/src/main/java/uk/gov/cshr/repository/IdentityRepository.java
+++ b/src/main/java/uk/gov/cshr/repository/IdentityRepository.java
@@ -2,16 +2,20 @@ package uk.gov.cshr.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.cshr.domain.Identity;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface IdentityRepository extends PagingAndSortingRepository<Identity, Long> {
+public interface IdentityRepository extends JpaRepository<Identity, Long> {
 
     Identity findFirstByActiveTrueAndEmailEquals(String email);
+
+    List<Identity> findByLastLoggedInBefore(Instant deactivationDate);
 
     Page<Identity> findAllByEmailContains(Pageable pageable, String email);
 

--- a/src/main/java/uk/gov/cshr/service/RequestEntityFactory.java
+++ b/src/main/java/uk/gov/cshr/service/RequestEntityFactory.java
@@ -18,6 +18,9 @@ import java.util.Arrays;
 @Component
 public class RequestEntityFactory {
 
+    @Value("${identity.url}")
+    private String identityUrl;
+
     @Value("${security.oauth2.client.client-id}")
     private String clientId;
 
@@ -26,7 +29,6 @@ public class RequestEntityFactory {
 
     @Value("${security.oauth2.client.access-token-uri}")
     private String clientUrl;
-
 
     public RequestEntity createDeleteRequest(URI uri) {
         return new RequestEntity(getOauth2HeadersFromSecurityContext(), HttpMethod.DELETE, uri);
@@ -41,8 +43,11 @@ public class RequestEntityFactory {
     }
 
     public RequestEntity createPostRequest(URI uri, Object body) {
-        getOauth2HeadersFromSecurityContext();
         return new RequestEntity(body, getOauth2HeadersFromSecurityContext(), HttpMethod.POST, uri);
+    }
+
+    public RequestEntity createGetRequest(URI uri, Object body) {
+        return new RequestEntity(body, getOauth2HeadersFromSecurityContext(), HttpMethod.GET, uri);
     }
 
     public RequestEntity createPostRequest(String uri, Object body) {
@@ -52,6 +57,15 @@ public class RequestEntityFactory {
             throw new RequestEntityException(e);
         }
     }
+
+    public RequestEntity createLogoutRequest() {
+        try {
+            return createGetRequest(new URI(String.format("%s/oauth/logout", identityUrl)), null);
+        } catch (URISyntaxException e) {
+            throw new RequestEntityException(e);
+        }
+    }
+
 
     private HttpHeaders getOauth2HeadersFromSecurityContext() {
         String token;

--- a/src/main/java/uk/gov/cshr/service/scheduler/Scheduler.java
+++ b/src/main/java/uk/gov/cshr/service/scheduler/Scheduler.java
@@ -1,5 +1,6 @@
 package uk.gov.cshr.service.scheduler;
 
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,8 +12,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 @Component
+@Slf4j
 public class Scheduler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Scheduler.class);
 
     private static final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
 
@@ -22,11 +23,8 @@ public class Scheduler {
     @Scheduled(cron = "0 0 5 * * *")
     public void trackUserActivity() {
         LOGGER.info("Executing trackUserActivity at {}", dateFormat.format(new Date()));
-
-        LOGGER.info("Skipping trackUserActivity at {}", dateFormat.format(new Date()));
-
-//        identityService.trackUserActivity();
-
+        identityService.trackUserActivity();
         LOGGER.info("trackUserActivity complete at {}", dateFormat.format(new Date()));
+
     }
 }

--- a/src/main/java/uk/gov/cshr/service/scheduler/Scheduler.java
+++ b/src/main/java/uk/gov/cshr/service/scheduler/Scheduler.java
@@ -1,8 +1,6 @@
 package uk.gov.cshr.service.scheduler;
 
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -22,9 +20,8 @@ public class Scheduler {
 
     @Scheduled(cron = "0 0 5 * * *")
     public void trackUserActivity() {
-        LOGGER.info("Executing trackUserActivity at {}", dateFormat.format(new Date()));
+        log.info("Executing trackUserActivity at {}", dateFormat.format(new Date()));
         identityService.trackUserActivity();
-        LOGGER.info("trackUserActivity complete at {}", dateFormat.format(new Date()));
-
+        log.info("trackUserActivity complete at {}", dateFormat.format(new Date()));
     }
 }

--- a/src/main/java/uk/gov/cshr/service/security/IdentityService.java
+++ b/src/main/java/uk/gov/cshr/service/security/IdentityService.java
@@ -1,7 +1,6 @@
 package uk.gov.cshr.service.security;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.ReadOnlyProperty;
@@ -12,14 +11,12 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 import uk.gov.cshr.domain.Identity;
 import uk.gov.cshr.notifications.service.MessageService;
 import uk.gov.cshr.notifications.service.NotificationService;
 import uk.gov.cshr.repository.IdentityRepository;
-import uk.gov.cshr.service.CSRSService;
-import uk.gov.cshr.service.InviteService;
-import uk.gov.cshr.service.ResetService;
-import uk.gov.cshr.service.TokenService;
+import uk.gov.cshr.service.*;
 import uk.gov.cshr.service.learnerRecord.LearnerRecordService;
 
 import java.time.LocalDateTime;
@@ -27,10 +24,9 @@ import java.time.ZoneOffset;
 import java.util.Optional;
 
 @Service
+@Slf4j
 @Transactional
 public class IdentityService implements UserDetailsService {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(IdentityService.class);
 
     private final IdentityRepository identityRepository;
 
@@ -54,6 +50,10 @@ public class IdentityService implements UserDetailsService {
 
     private final int deletionMonths;
 
+    private final RequestEntityFactory requestEntityFactory;
+
+    private final RestTemplate restTemplate;
+
     public IdentityService(@Value("${accountPeriodsInMonths.deactivation}") int deactivation,
                            @Value("${accountPeriodsInMonths.notification}") int notification,
                            @Value("${accountPeriodsInMonths.deletion}") int deletion,
@@ -63,7 +63,9 @@ public class IdentityService implements UserDetailsService {
                            NotificationService notificationService,
                            MessageService messageService,
                            ResetService resetService,
-                           TokenService tokenService) {
+                           TokenService tokenService,
+                           RestTemplate restTemplate,
+                           RequestEntityFactory requestEntityFactory) {
         this.identityRepository = identityRepository;
         this.learnerRecordService = learnerRecordService;
         this.csrsService = csrsService;
@@ -74,6 +76,8 @@ public class IdentityService implements UserDetailsService {
         this.deletionMonths = deletion;
         this.resetService = resetService;
         this.tokenService = tokenService;
+        this.requestEntityFactory = requestEntityFactory;
+        this.restTemplate = restTemplate;
     }
 
     @Autowired
@@ -112,6 +116,7 @@ public class IdentityService implements UserDetailsService {
                     resetService.deleteResetsByIdentity(identity);
                     tokenService.deleteTokensByIdentity(identity);
                     identityRepository.delete(identity);
+                    identityRepository.flush();
                 }
             }
         }
@@ -119,33 +124,45 @@ public class IdentityService implements UserDetailsService {
 
     @Transactional
     public void trackUserActivity() {
-        Iterable<Identity> identities = identityRepository.findAll();
+        log.info("Staring trackUserActivity");
 
         LocalDateTime deactivationDate = LocalDateTime.now().minusMonths(deactivationMonths);
         LocalDateTime deletionNotificationDate = LocalDateTime.now().minusMonths(notificationMonths);
         LocalDateTime deletionDate = LocalDateTime.now().minusMonths(deletionMonths);
 
-        LOGGER.info("deactiviation date {}, deleteNotifyDate {}, deleteDate {}", deactivationDate, deletionNotificationDate, deletionDate);
+        log.info("deactivation date {}, deleteNotifyDate {}, deleteDate {}", deactivationDate, deletionNotificationDate, deletionDate);
+
+        Iterable<Identity> identities = identityRepository.findByLastLoggedInBefore(deactivationDate.toInstant(ZoneOffset.UTC));
 
         identities.forEach(identity -> {
             LocalDateTime lastLoggedIn = LocalDateTime.ofInstant(identity.getLastLoggedIn(), ZoneOffset.UTC);
 
             if (lastLoggedIn.isBefore(deletionDate)) {
-                LOGGER.info("deleting identity {} ", identity.getEmail());
+                log.info("deleting identity {} ", identity.getEmail());
                 notificationService.send(messageService.createDeletedMessage(identity));
                 deleteIdentity(identity.getUid());
             } else if (lastLoggedIn.isBefore(deletionNotificationDate) && !identity.isDeletionNotificationSent()) {
-                LOGGER.info("sending notify {} ", identity.getEmail());
+                log.info("sending notify {} ", identity.getEmail());
                 notificationService.send(messageService.createDeletionMessage(identity));
                 identity.setDeletionNotificationSent(true);
-                identityRepository.save(identity);
+                identityRepository.saveAndFlush(identity);
             } else if (identity.isActive() && lastLoggedIn.isBefore(deactivationDate)) {
-                LOGGER.info("deactivating identity {} ", identity.getEmail());
+                log.info("deactivating identity {} ", identity.getEmail());
                 notificationService.send(messageService.createSuspensionMessage(identity));
                 identity.setActive(false);
-                identityRepository.save(identity);
+                identityRepository.saveAndFlush(identity);
             }
         });
+      
+
+        if (restTemplate.exchange(requestEntityFactory.createLogoutRequest(), Void.class).getStatusCode().is2xxSuccessful()) {
+            log.info("Management client user logged out after data retention execution");
+        } else {
+            log.error("Error logging out management client user after data retention execution, this may cause future executions to be unstable");
+        }
+      
+      log.info("Finished trackUserActivity");
+
     }
 
     public void clearUserTokens(Identity identity) {

--- a/src/main/java/uk/gov/cshr/service/security/IdentityService.java
+++ b/src/main/java/uk/gov/cshr/service/security/IdentityService.java
@@ -124,7 +124,7 @@ public class IdentityService implements UserDetailsService {
 
     @Transactional
     public void trackUserActivity() {
-        log.info("Staring trackUserActivity");
+        log.info("Starting trackUserActivity");
 
         LocalDateTime deactivationDate = LocalDateTime.now().minusMonths(deactivationMonths);
         LocalDateTime deletionNotificationDate = LocalDateTime.now().minusMonths(notificationMonths);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,8 @@ security:
       user-authorization-uri: ${OAUTH_URL:http://localhost:8080}/oauth/authorize
       reset-uri: ${OAUTH_URL:http://localhost:8080}/reset
 
+identity:
+  url: ${OAUTH_URL:http://localhost:8080}
 
 invite:
   url: ${INVITE_SIGNUP_URL:http://localhost:8080/signup/%s}
@@ -58,7 +60,7 @@ spring:
   thymeleaf:
     cache: true
   datasource:
-    url: ${DATASOURCE:jdbc:mysql://localhost:3306/oauth2?user=root&password=password&useSSL=false}
+    url: ${DATASOURCE:jdbc:mysql://localhost:3306/identity?user=root&password=password&useSSL=false}
     platform: mysql
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:

--- a/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
@@ -1,0 +1,278 @@
+package uk.gov.cshr.service.security;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.ResponseEntity;
+import uk.gov.cshr.domain.Identity;
+import uk.gov.cshr.domain.Role;
+import uk.gov.cshr.notifications.dto.MessageDto;
+import uk.gov.cshr.notifications.service.MessageService;
+import uk.gov.cshr.notifications.service.NotificationService;
+import uk.gov.cshr.repository.IdentityRepository;
+import uk.gov.cshr.service.CSRSService;
+import uk.gov.cshr.service.InviteService;
+import uk.gov.cshr.service.ResetService;
+import uk.gov.cshr.service.TokenService;
+import uk.gov.cshr.service.learnerRecord.LearnerRecordService;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdentityServiceTest {
+
+    private static final int DEACTIVATION_MONTH = 1;
+    private static final int NOTIFICATION_MONTH = 2;
+    private static final int DELETION_MONTH = 3;
+
+    // LLIT - Last Logged In Time
+    // Remove an extra day from the LLIT avoid any issue with tests running to quickly
+    private static final Instant DEACTIVATION_LLIT = LocalDateTime.now().minusMonths(DEACTIVATION_MONTH).minusDays(1).toInstant(ZoneOffset.UTC);
+    private static final Instant NOTIFICATION_LLIT = LocalDateTime.now().minusMonths(NOTIFICATION_MONTH).minusDays(1).toInstant(ZoneOffset.UTC);
+    private static final Instant DELETION_LLIT = LocalDateTime.now().minusMonths(DELETION_MONTH).minusDays(1).toInstant(ZoneOffset.UTC);
+
+    private static final boolean USER_ACTIVE = true;
+    private static final boolean USER_DEACTIVATED = false;
+
+    private static final boolean USER_NOT_LOCKED = false;
+
+    private static final boolean DELETE_NOTIFICATION_SENT = true;
+    private static final boolean DELETE_NOTIFICATION_NOT_SENT = false;
+
+    private static final Set<Role> DEFAULT_ROLE_SET = Collections.EMPTY_SET;
+
+    @Mock
+    private IdentityRepository identityRepository;
+    @Mock
+    private InviteService inviteService;
+    @Mock
+    private ResetService resetService;
+    @Mock
+    private TokenService tokenService;
+    @Mock
+    private LearnerRecordService learnerRecordService;
+    @Mock
+    private CSRSService csrsService;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private MessageService messageService;
+
+    private IdentityService identityService;
+
+    @Before
+    public void createIdentityService() {
+        identityService = new IdentityService(DEACTIVATION_MONTH, NOTIFICATION_MONTH, DELETION_MONTH, identityRepository, learnerRecordService, csrsService, notificationService, messageService, resetService, tokenService);
+        identityService.setInviteService(inviteService);
+    }
+
+    @Test
+    public void trackUserActivity_NoActionsWhenNoUsersInRanges() {
+
+        List<Identity> userList = new ArrayList<>();
+        userList.add(new Identity(UUID.randomUUID().toString(), "email", "password", USER_ACTIVE, USER_NOT_LOCKED, DEFAULT_ROLE_SET, Instant.now(), DELETE_NOTIFICATION_NOT_SENT));
+
+        when(identityRepository.findAll()).thenReturn(userList);
+        identityService.trackUserActivity();
+
+        verify(identityRepository, times(1)).findAll();
+
+        verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+
+    }
+
+    @Test
+    public void trackUserActivity_DeactivationWhenUserInDeactivationRange() {
+
+        Identity deactivationUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_ACTIVE, USER_NOT_LOCKED, DEFAULT_ROLE_SET, DEACTIVATION_LLIT, DELETE_NOTIFICATION_NOT_SENT);
+        MessageDto deactivationNotification = new MessageDto();
+
+        List<Identity> userList = new ArrayList<>();
+        userList.add(deactivationUser);
+
+        when(identityRepository.findAll()).thenReturn(userList);
+        when(messageService.createSuspensionMessage(deactivationUser)).thenReturn(deactivationNotification);
+
+        identityService.trackUserActivity();
+
+        verify(identityRepository, times(1)).findAll();
+        verify(messageService, times(1)).createSuspensionMessage(deactivationUser);
+        verify(notificationService, times(1)).send(deactivationNotification);
+        verify(identityRepository, times(1)).save(deactivationUser);
+
+        verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+
+
+        assertFalse(deactivationUser.isActive());
+
+    }
+
+    @Test
+    public void trackUserActivity_NoDeactivationWhenUserInDeactivationRangeButAlreadyDeactivated() {
+        Identity deactivationUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_DEACTIVATED, USER_NOT_LOCKED, DEFAULT_ROLE_SET, DEACTIVATION_LLIT, DELETE_NOTIFICATION_NOT_SENT);
+
+        List<Identity> userList = new ArrayList<>();
+        userList.add(deactivationUser);
+
+        when(identityRepository.findAll()).thenReturn(userList);
+
+        identityService.trackUserActivity();
+
+        verify(identityRepository, times(1)).findAll();
+
+        verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+    }
+
+
+    @Test
+    public void trackUserActivity_NotificationWhenUserInNotificationRange() {
+        Identity notificationUserDeactivated = new Identity(UUID.randomUUID().toString(), "email", "password", USER_DEACTIVATED, USER_NOT_LOCKED, DEFAULT_ROLE_SET, NOTIFICATION_LLIT, DELETE_NOTIFICATION_NOT_SENT);
+        Identity notificationUserActive = new Identity(UUID.randomUUID().toString(), "email", "password", USER_ACTIVE, USER_NOT_LOCKED, DEFAULT_ROLE_SET, NOTIFICATION_LLIT, DELETE_NOTIFICATION_NOT_SENT);
+
+        MessageDto deletionWarningNotification = new MessageDto();
+
+        List<Identity> userList = new ArrayList<>();
+        userList.add(notificationUserDeactivated);
+        userList.add(notificationUserActive);
+
+        when(identityRepository.findAll()).thenReturn(userList);
+        when(messageService.createDeletionMessage(notificationUserDeactivated)).thenReturn(deletionWarningNotification);
+        when(messageService.createDeletionMessage(notificationUserActive)).thenReturn(deletionWarningNotification);
+
+        identityService.trackUserActivity();
+
+        verify(identityRepository, times(1)).findAll();
+        verify(messageService, times(1)).createDeletionMessage(notificationUserActive);
+        verify(messageService, times(1)).createDeletionMessage(notificationUserDeactivated);
+        verify(notificationService, times(2)).send(deletionWarningNotification);
+        verify(identityRepository, times(1)).save(notificationUserDeactivated);
+        verify(identityRepository, times(1)).save(notificationUserActive);
+        verifyNoMoreInteractions(identityRepository);
+
+        verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+
+        for (Identity user : userList) {
+            assertTrue(user.isDeletionNotificationSent());
+        }
+    }
+
+    @Test
+    public void trackUserActivity_NoNotificationSentWhenUserInNotificationRangeButNotificationAlreadySent() {
+        Identity notificationUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_DEACTIVATED, USER_NOT_LOCKED, DEFAULT_ROLE_SET, NOTIFICATION_LLIT, DELETE_NOTIFICATION_SENT);
+
+        List<Identity> userList = new ArrayList<>();
+        userList.add(notificationUser);
+
+        when(identityRepository.findAll()).thenReturn(userList);
+
+        identityService.trackUserActivity();
+
+        verify(identityRepository, times(1)).findAll();
+        verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+    }
+
+    @Test
+    public void trackUserActivity_DeletionWhenUserInDeletionRange() {
+        Identity deletionUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_DEACTIVATED, USER_NOT_LOCKED, DEFAULT_ROLE_SET, DELETION_LLIT, DELETE_NOTIFICATION_SENT);
+        MessageDto deletionNotification = new MessageDto();
+        List<Identity> userList = new ArrayList<>();
+        userList.add(deletionUser);
+
+        when(identityRepository.findAll()).thenReturn(userList);
+        when(messageService.createDeletedMessage(deletionUser)).thenReturn(deletionNotification);
+        when(learnerRecordService.deleteCivilServant(deletionUser.getUid())).thenReturn(ResponseEntity.noContent().build());
+        when(csrsService.deleteCivilServant(deletionUser.getUid())).thenReturn(ResponseEntity.noContent().build());
+        when(identityRepository.findFirstByUid(deletionUser.getUid())).thenReturn(Optional.of(deletionUser));
+
+        identityService.trackUserActivity();
+
+        verify(identityRepository, times(1)).findAll();
+        verify(messageService, times(1)).createDeletedMessage(deletionUser);
+        verify(notificationService, times(1)).send(deletionNotification);
+        verify(learnerRecordService, times(1)).deleteCivilServant(deletionUser.getUid());
+        verify(csrsService, times(1)).deleteCivilServant(deletionUser.getUid());
+        verify(identityRepository, times(1)).findFirstByUid(deletionUser.getUid());
+        verify(inviteService, times(1)).deleteInvitesByIdentity(deletionUser);
+        verify(resetService, times(1)).deleteResetsByIdentity(deletionUser);
+        verify(tokenService, times(1)).deleteTokensByIdentity(deletionUser);
+        verify(identityRepository, times(1)).delete(deletionUser);
+
+        verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+    }
+
+    @Test
+    public void trackUserActivity_MixActionWhenUsersInMixRange() {
+        Identity deactivationUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_ACTIVE, USER_NOT_LOCKED, DEFAULT_ROLE_SET, DEACTIVATION_LLIT, DELETE_NOTIFICATION_NOT_SENT);
+        Identity notificationUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_DEACTIVATED, USER_NOT_LOCKED, DEFAULT_ROLE_SET, NOTIFICATION_LLIT, DELETE_NOTIFICATION_NOT_SENT);
+        Identity deletionUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_DEACTIVATED, USER_NOT_LOCKED, DEFAULT_ROLE_SET, DELETION_LLIT, DELETE_NOTIFICATION_SENT);
+
+        MessageDto deactivationNotification = new MessageDto();
+        MessageDto deletionWarningNotification = new MessageDto();
+        MessageDto deletionNotification = new MessageDto();
+
+        deactivationNotification.setTemplateId(UUID.randomUUID().toString());
+        deletionWarningNotification.setTemplateId(UUID.randomUUID().toString());
+        deletionNotification.setTemplateId(UUID.randomUUID().toString());
+
+        List<Identity> userList = new ArrayList<>();
+        userList.add(deactivationUser);
+        userList.add(notificationUser);
+        userList.add(deletionUser);
+
+        when(identityRepository.findAll()).thenReturn(userList);
+        when(messageService.createSuspensionMessage(deactivationUser)).thenReturn(deactivationNotification);
+        when(messageService.createDeletionMessage(notificationUser)).thenReturn(deletionWarningNotification);
+        when(messageService.createDeletedMessage(deletionUser)).thenReturn(deletionNotification);
+        when(learnerRecordService.deleteCivilServant(deletionUser.getUid())).thenReturn(ResponseEntity.noContent().build());
+        when(csrsService.deleteCivilServant(deletionUser.getUid())).thenReturn(ResponseEntity.noContent().build());
+        when(identityRepository.findFirstByUid(deletionUser.getUid())).thenReturn(Optional.of(deletionUser));
+
+        identityService.trackUserActivity();
+
+        verify(identityRepository, times(1)).findAll();
+
+        verify(notificationService, times(1)).send(deactivationNotification);
+        verify(notificationService, times(1)).send(deletionWarningNotification);
+        verify(notificationService, times(1)).send(deletionNotification);
+
+        verify(identityRepository, times(1)).save(deactivationUser);
+        verify(identityRepository, times(1)).save(notificationUser);
+        verify(identityRepository, times(1)).delete(deletionUser);
+
+        verify(messageService, times(1)).createSuspensionMessage(deactivationUser);
+        verify(messageService, times(1)).createDeletionMessage(notificationUser);
+        verify(messageService, times(1)).createDeletedMessage(deletionUser);
+
+        verify(learnerRecordService, times(1)).deleteCivilServant(deletionUser.getUid());
+        verify(csrsService, times(1)).deleteCivilServant(deletionUser.getUid());
+        verify(identityRepository, times(1)).findFirstByUid(deletionUser.getUid());
+        verify(inviteService, times(1)).deleteInvitesByIdentity(deletionUser);
+        verify(resetService, times(1)).deleteResetsByIdentity(deletionUser);
+        verify(tokenService, times(1)).deleteTokensByIdentity(deletionUser);
+
+        verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+
+        assertFalse(deactivationUser.isActive());
+        assertTrue(notificationUser.isDeletionNotificationSent());
+
+    }
+
+    @Test
+    public void trackUserActivity_NoErrorWhenNoUsers() {
+        when(identityRepository.findAll()).thenReturn(Collections.EMPTY_LIST);
+        identityService.trackUserActivity();
+
+        verifyZeroInteractions(notificationService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
+        verify(identityRepository, times(1)).findAll();
+        verifyNoMoreInteractions(identityRepository);
+    }
+}

--- a/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
+++ b/src/test/java/uk/gov/cshr/service/security/IdentityServiceTest.java
@@ -1,21 +1,21 @@
 package uk.gov.cshr.service.security;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 import uk.gov.cshr.domain.Identity;
 import uk.gov.cshr.domain.Role;
 import uk.gov.cshr.notifications.dto.MessageDto;
 import uk.gov.cshr.notifications.service.MessageService;
 import uk.gov.cshr.notifications.service.NotificationService;
 import uk.gov.cshr.repository.IdentityRepository;
-import uk.gov.cshr.service.CSRSService;
-import uk.gov.cshr.service.InviteService;
-import uk.gov.cshr.service.ResetService;
-import uk.gov.cshr.service.TokenService;
+import uk.gov.cshr.service.*;
 import uk.gov.cshr.service.learnerRecord.LearnerRecordService;
 
 import java.time.Instant;
@@ -66,28 +66,49 @@ public class IdentityServiceTest {
     private NotificationService notificationService;
     @Mock
     private MessageService messageService;
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private RequestEntityFactory requestEntityFactory;
 
     private IdentityService identityService;
 
+    private RequestEntity requestEntity = RequestEntity.get(null).build();
+    private ResponseEntity responseEntity = ResponseEntity.ok().build();
+
     @Before
     public void createIdentityService() {
-        identityService = new IdentityService(DEACTIVATION_MONTH, NOTIFICATION_MONTH, DELETION_MONTH, identityRepository, learnerRecordService, csrsService, notificationService, messageService, resetService, tokenService);
+        identityService = new IdentityService(DEACTIVATION_MONTH, NOTIFICATION_MONTH, DELETION_MONTH, identityRepository, learnerRecordService, csrsService, notificationService, messageService, resetService, tokenService, restTemplate, requestEntityFactory);
         identityService.setInviteService(inviteService);
+
+        when(requestEntityFactory.createLogoutRequest()).thenReturn(requestEntity);
+        when(restTemplate.exchange(requestEntity, Void.class)).thenReturn(responseEntity);
+    }
+
+    @After
+    public void globalLogoutCheck() {
+        verify(requestEntityFactory, times(1)).createLogoutRequest();
+        verify(restTemplate, times(1)).exchange(requestEntity, Void.class);
+        verifyNoMoreInteractions(requestEntityFactory, restTemplate);
     }
 
     @Test
     public void trackUserActivity_NoActionsWhenNoUsersInRanges() {
 
-        List<Identity> userList = new ArrayList<>();
-        userList.add(new Identity(UUID.randomUUID().toString(), "email", "password", USER_ACTIVE, USER_NOT_LOCKED, DEFAULT_ROLE_SET, Instant.now(), DELETE_NOTIFICATION_NOT_SENT));
+        Identity noActionUser = new Identity(UUID.randomUUID().toString(), "email", "password", USER_ACTIVE, USER_NOT_LOCKED, DEFAULT_ROLE_SET, Instant.now(), DELETE_NOTIFICATION_NOT_SENT);
 
-        when(identityRepository.findAll()).thenReturn(userList);
+        List<Identity> userList = new ArrayList<>();
+        userList.add(noActionUser);
+
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(userList);
         identityService.trackUserActivity();
 
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
 
         verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
 
+        assertTrue(noActionUser.isActive());
+        assertFalse(noActionUser.isDeletionNotificationSent());
     }
 
     @Test
@@ -99,21 +120,19 @@ public class IdentityServiceTest {
         List<Identity> userList = new ArrayList<>();
         userList.add(deactivationUser);
 
-        when(identityRepository.findAll()).thenReturn(userList);
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(userList);
         when(messageService.createSuspensionMessage(deactivationUser)).thenReturn(deactivationNotification);
 
         identityService.trackUserActivity();
 
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
         verify(messageService, times(1)).createSuspensionMessage(deactivationUser);
         verify(notificationService, times(1)).send(deactivationNotification);
-        verify(identityRepository, times(1)).save(deactivationUser);
+        verify(identityRepository, times(1)).saveAndFlush(deactivationUser);
 
         verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
 
-
         assertFalse(deactivationUser.isActive());
-
     }
 
     @Test
@@ -123,11 +142,11 @@ public class IdentityServiceTest {
         List<Identity> userList = new ArrayList<>();
         userList.add(deactivationUser);
 
-        when(identityRepository.findAll()).thenReturn(userList);
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(userList);
 
         identityService.trackUserActivity();
 
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
 
         verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
     }
@@ -144,18 +163,18 @@ public class IdentityServiceTest {
         userList.add(notificationUserDeactivated);
         userList.add(notificationUserActive);
 
-        when(identityRepository.findAll()).thenReturn(userList);
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(userList);
         when(messageService.createDeletionMessage(notificationUserDeactivated)).thenReturn(deletionWarningNotification);
         when(messageService.createDeletionMessage(notificationUserActive)).thenReturn(deletionWarningNotification);
 
         identityService.trackUserActivity();
 
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
         verify(messageService, times(1)).createDeletionMessage(notificationUserActive);
         verify(messageService, times(1)).createDeletionMessage(notificationUserDeactivated);
         verify(notificationService, times(2)).send(deletionWarningNotification);
-        verify(identityRepository, times(1)).save(notificationUserDeactivated);
-        verify(identityRepository, times(1)).save(notificationUserActive);
+        verify(identityRepository, times(1)).saveAndFlush(notificationUserDeactivated);
+        verify(identityRepository, times(1)).saveAndFlush(notificationUserActive);
         verifyNoMoreInteractions(identityRepository);
 
         verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
@@ -172,11 +191,11 @@ public class IdentityServiceTest {
         List<Identity> userList = new ArrayList<>();
         userList.add(notificationUser);
 
-        when(identityRepository.findAll()).thenReturn(userList);
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(userList);
 
         identityService.trackUserActivity();
 
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
         verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
     }
 
@@ -187,7 +206,7 @@ public class IdentityServiceTest {
         List<Identity> userList = new ArrayList<>();
         userList.add(deletionUser);
 
-        when(identityRepository.findAll()).thenReturn(userList);
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(userList);
         when(messageService.createDeletedMessage(deletionUser)).thenReturn(deletionNotification);
         when(learnerRecordService.deleteCivilServant(deletionUser.getUid())).thenReturn(ResponseEntity.noContent().build());
         when(csrsService.deleteCivilServant(deletionUser.getUid())).thenReturn(ResponseEntity.noContent().build());
@@ -195,7 +214,7 @@ public class IdentityServiceTest {
 
         identityService.trackUserActivity();
 
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
         verify(messageService, times(1)).createDeletedMessage(deletionUser);
         verify(notificationService, times(1)).send(deletionNotification);
         verify(learnerRecordService, times(1)).deleteCivilServant(deletionUser.getUid());
@@ -205,6 +224,7 @@ public class IdentityServiceTest {
         verify(resetService, times(1)).deleteResetsByIdentity(deletionUser);
         verify(tokenService, times(1)).deleteTokensByIdentity(deletionUser);
         verify(identityRepository, times(1)).delete(deletionUser);
+        verify(identityRepository, times(1)).flush();
 
         verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
     }
@@ -228,7 +248,7 @@ public class IdentityServiceTest {
         userList.add(notificationUser);
         userList.add(deletionUser);
 
-        when(identityRepository.findAll()).thenReturn(userList);
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(userList);
         when(messageService.createSuspensionMessage(deactivationUser)).thenReturn(deactivationNotification);
         when(messageService.createDeletionMessage(notificationUser)).thenReturn(deletionWarningNotification);
         when(messageService.createDeletedMessage(deletionUser)).thenReturn(deletionNotification);
@@ -238,14 +258,14 @@ public class IdentityServiceTest {
 
         identityService.trackUserActivity();
 
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
 
         verify(notificationService, times(1)).send(deactivationNotification);
         verify(notificationService, times(1)).send(deletionWarningNotification);
         verify(notificationService, times(1)).send(deletionNotification);
 
-        verify(identityRepository, times(1)).save(deactivationUser);
-        verify(identityRepository, times(1)).save(notificationUser);
+        verify(identityRepository, times(1)).saveAndFlush(deactivationUser);
+        verify(identityRepository, times(1)).saveAndFlush(notificationUser);
         verify(identityRepository, times(1)).delete(deletionUser);
 
         verify(messageService, times(1)).createSuspensionMessage(deactivationUser);
@@ -258,6 +278,7 @@ public class IdentityServiceTest {
         verify(inviteService, times(1)).deleteInvitesByIdentity(deletionUser);
         verify(resetService, times(1)).deleteResetsByIdentity(deletionUser);
         verify(tokenService, times(1)).deleteTokensByIdentity(deletionUser);
+        verify(identityRepository, times(1)).flush();
 
         verifyNoMoreInteractions(identityRepository, notificationService, messageService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
 
@@ -268,11 +289,11 @@ public class IdentityServiceTest {
 
     @Test
     public void trackUserActivity_NoErrorWhenNoUsers() {
-        when(identityRepository.findAll()).thenReturn(Collections.EMPTY_LIST);
+        when(identityRepository.findByLastLoggedInBefore(any())).thenReturn(Collections.EMPTY_LIST);
         identityService.trackUserActivity();
 
         verifyZeroInteractions(notificationService, learnerRecordService, csrsService, inviteService, resetService, tokenService);
-        verify(identityRepository, times(1)).findAll();
+        verify(identityRepository, times(1)).findByLastLoggedInBefore(any());
         verifyNoMoreInteractions(identityRepository);
     }
 }


### PR DESCRIPTION
LC-666 - data retention job improvements

- changing identity roles to use lazy fetch
- change db query to only return identities that have a last logged in time before the deactivation date
- force a flush after user updates to avoid database transaction timeouts when many users are being processed
- for log out of client user after job to ensure job always generates a fresh oauth token
- unit tests