### PR TITLE
LC 2906 search for user

### DIFF
--- a/src/main/java/uk/gov/cshr/controller/IdentityController.java
+++ b/src/main/java/uk/gov/cshr/controller/IdentityController.java
@@ -58,6 +58,7 @@ public class IdentityController {
         log.debug("Listing all identities");
 
         Page<Identity> pages = query == null || query.isEmpty() ? identityRepository.findAll(pageable) : identityRepository.findAllByEmailContains(pageable, query);
+
         model.addAttribute("page", pages);
         model.addAttribute("query", query == null ? "" : query);
         model.addAttribute("pagination", Pagination.generateList(pages.getNumber(), pages.getTotalPages()));

--- a/src/main/java/uk/gov/cshr/controller/IdentityController.java
+++ b/src/main/java/uk/gov/cshr/controller/IdentityController.java
@@ -88,9 +88,12 @@ public class IdentityController {
             }
             CivilServantDto civilServantDto = csrsService.getCivilServant(uid);
             identity.setLastReactivation(this.reactivationService.getLatestReactivationForEmail(identity.getEmail()));
-            List<?> requiredCourses = civilServantDto == null ? emptyList() : cslService.getRequiredLearningForUser(uid).getCourses();
-            model.addAttribute(IDENTITY_ATTRIBUTE, identity);
+            List<?> requiredCourses = emptyList();
+            if (civilServantDto != null && civilServantDto.getOrganisationalUnit() != null) {
+                requiredCourses = cslService.getRequiredLearningForUser(uid).getCourses();
+            }
             model.addAttribute("requiredCourses", requiredCourses);
+            model.addAttribute(IDENTITY_ATTRIBUTE, identity);
             model.addAttribute("roles", roles);
             model.addAttribute("profile", civilServantDto);
             model.addAttribute("token", agencyToken);

--- a/src/main/resources/templates/identity/list.html
+++ b/src/main/resources/templates/identity/list.html
@@ -36,7 +36,7 @@
             <th scope="col" id="activeheader">Active</th>
             <th scope="col" id="lockedheader">Locked</th>
             <th scope="col">Email</th>
-            <th scope="col">Action</th>
+            <th scope="col" th:if="${@frontendAuthService.hasPermission(T(uk.gov.cshr.config.Permission).DELETE_IDENTITY)}">Action</th>
         </tr>
         </thead>
         <tbody>
@@ -46,7 +46,7 @@
             <td>
                 <a th:text="${identity.email}" th:href="@{|/identities/update/${identity.uid}|}" th:alt="'View user ' + ${identity.email}"></a>
             </td>
-            <td>
+            <td th:if="${@frontendAuthService.hasPermission(T(uk.gov.cshr.config.Permission).DELETE_IDENTITY)}">
                 <a class="btn btn-danger btn-sm" th:href="@{|/identities/delete/${identity.uid}|}">
                     Delete
                 </a>


### PR DESCRIPTION
- On the identities search page, prevent users from seeing the delete button if they do not have the required role
- Don't fetch required learning if the user's department is blank (bugfix)